### PR TITLE
Fixed paths in fs/aufs/Makefile

### DIFF
--- a/fs/aufs/Makefile
+++ b/fs/aufs/Makefile
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: GPL-2.0
 
-include ${src}/magic.mk
+include ${srctree}/${src}/magic.mk
 ifeq (${CONFIG_AUFS_FS},m)
-include ${src}/conf.mk
+include ${srctree}/${src}/conf.mk
 endif
--include ${src}/priv_def.mk
+-include ${srctree}/${src}/priv_def.mk
 
 # cf. include/linux/kernel.h
 # enable pr_debug


### PR DESCRIPTION
Hi sfjro.

I had to fix some paths in `fs/aufs/Makefile` for making it compile on my 6.6.36 kernel (the kernel is being built as a part of a Yocto compilation)

The modification seems to me reasonable, and I truly think it can be integrated into master (and all other branches)... isn't it? Am I missing something?

