### PR TITLE
aufs: fix build errors in linux-5.15

### DIFF
--- a/fs/aufs/hfsnotify.c
+++ b/fs/aufs/hfsnotify.c
@@ -238,7 +238,8 @@ static int au_hfsn_init_br(struct au_branch *br, int perm)
 		goto out;
 
 	err = 0;
-	group = fsnotify_alloc_group(&au_hfsn_ops);
+	group = fsnotify_alloc_group(&au_hfsn_ops,
+				     /*flags - not for userspace*/0);
 	if (IS_ERR(group)) {
 		err = PTR_ERR(group);
 		pr_err("fsnotify_alloc_group() failed, %d\n", err);


### PR DESCRIPTION
Currently, allyesconfig test runs for x86_64 fail with: ERROR: fs/aufs/hfsnotify.c:241:17: error: too few arguments to function 'fsnotify_alloc_group'
|   241 |         group = fsnotify_alloc_group(&au_hfsn_ops);